### PR TITLE
Remove github-actions label from dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,5 @@ updates:
       day: monday
     labels:
       - dependencies
-      - github-actions
     commit-message:
       prefix: "chore(ci)"


### PR DESCRIPTION
## What

Removed the `github-actions` label from the dependabot configuration for dependency updates. This label will no longer be automatically applied to pull requests created by dependabot for dependency updates.

## Why

Simplifying the labeling strategy for dependabot PRs. The `dependencies` label is sufficient for categorizing these updates, and the `github-actions` label was redundant or no longer needed for the workflow.

## Test plan

N/A - Configuration change only. Dependabot behavior will be verified on the next automated run.

## Bring docs link

N/A

https://claude.ai/code/session_013jyQ6jg35VSKQ9yNjvFkKq