### PR TITLE
Move customerNumber from request root into each consignment's product

### DIFF
--- a/src/v4/Endpoint/Booking/BookingRequest.php
+++ b/src/v4/Endpoint/Booking/BookingRequest.php
@@ -70,14 +70,31 @@ final class BookingRequest
     /** @return array<string, mixed> */
     public function toArray(): array
     {
+        // Bring's Booking API expects customerNumber inside each
+        // consignment's product object — not at the request root. Posting
+        // it at the root produces a per-consignment BOOK-INPUT-019
+        // ("Customer number must be provided") even though the SDK
+        // constructor enforces a non-empty value, because Bring reads it
+        // from the product slot and finds nothing there.
+        //
+        // We model customerNumber once on the request (it's per-request in
+        // practice) and inject it into each consignment's product at
+        // serialization time, so the public SDK shape stays unchanged.
+        $customerNumber = $this->customerNumber;
+        $consignments = array_map(
+            static function (Consignment $c) use ($customerNumber): array {
+                $arr = $c->toArray();
+                $arr['product'] = ['customerNumber' => $customerNumber] + (array) $arr['product'];
+
+                return $arr;
+            },
+            $this->consignments,
+        );
+
         return [
             'schemaVersion' => $this->schemaVersion,
-            'consignments' => array_map(
-                static fn (Consignment $c): array => $c->toArray(),
-                $this->consignments,
-            ),
+            'consignments' => $consignments,
             'testIndicator' => $this->testIndicator,
-            'customerNumber' => $this->customerNumber,
         ];
     }
 }

--- a/src/v4/Endpoint/Booking/BookingRequest.php
+++ b/src/v4/Endpoint/Booking/BookingRequest.php
@@ -84,7 +84,7 @@ final class BookingRequest
         $consignments = array_map(
             static function (Consignment $c) use ($customerNumber): array {
                 $arr = $c->toArray();
-                $arr['product'] = ['customerNumber' => $customerNumber] + (array) $arr['product'];
+                $arr['product']['customerNumber'] = $customerNumber;
 
                 return $arr;
             },

--- a/tests/v4/Endpoint/Booking/BookingApiTest.php
+++ b/tests/v4/Endpoint/Booking/BookingApiTest.php
@@ -64,7 +64,8 @@ final class BookingApiTest extends TestCase
 
         $body = json_decode((string) $req->getBody(), true);
         self::assertSame('1', $body['schemaVersion']);
-        self::assertSame('PARCELS_NORWAY-10001234567', $body['customerNumber']);
+        self::assertArrayNotHasKey('customerNumber', $body, 'customerNumber must not be at request root — Bring expects it under consignments[].product');
+        self::assertSame('PARCELS_NORWAY-10001234567', $body['consignments'][0]['product']['customerNumber']);
         self::assertTrue($body['testIndicator']);
         self::assertSame(Product::HOME_DELIVERY_PARCEL->value, $body['consignments'][0]['product']['id']);
         self::assertSame('EVARSLING', $body['consignments'][0]['product']['additionalServices'][0]['id']);


### PR DESCRIPTION
## Summary

Bring's Booking API expects `customerNumber` inside `consignments[].product.customerNumber`, but the SDK was emitting it at the request root. Bring's gateway reads from the product slot, finds nothing, and rejects every consignment with `BOOK-INPUT-019 "Customer number must be provided"`. The `BookingRequest` constructor invariant (non-empty `customerNumber`) prevented a local failure but couldn't help the wire shape — every live booking would fail.

This was masked because the existing `BookingApiTest` only validated the (incorrect) root placement against a mock client.

## Change

- `BookingRequest::toArray()` no longer emits `customerNumber` at the root. Instead, it injects the field into each consignment's product object at serialization time.
- The public SDK shape is unchanged: callers still pass `customerNumber` once on `BookingRequest`. The repetition Bring's schema demands per consignment is an implementation detail.
- Test updated to pin the field at `consignments[0].product.customerNumber` AND to assert it is NOT present at the root, locking in the correct shape against the live API.

Confirmed against https://developer.bring.com/api/booking/ — the schema lists `customerNumber` as a required property of the product object inside each consignment.

## Test plan

- [x] `vendor/bin/phpunit` — 198 tests, all green
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `BookingApiTest` now asserts the field at the product level and explicitly forbids the root placement

---
_Generated by [Claude Code](https://claude.ai/code/session_019aSYHW5dD7tg3EJkFp8C9w)_