### PR TITLE
Send numeric service code in product.id for Booking API

### DIFF
--- a/src/v4/Endpoint/Booking/BookingProduct.php
+++ b/src/v4/Endpoint/Booking/BookingProduct.php
@@ -24,7 +24,11 @@ final class BookingProduct
     /** @return array<string, mixed> */
     public function toArray(): array
     {
-        $a = ['id' => $this->id->value];
+        // Booking API wants the numeric service code in product.id, not the
+        // string enum value the Shipping Guide uses (see Product::bookingProductId
+        // for the why). Falls back to the string value for products without a
+        // known numeric mapping.
+        $a = ['id' => $this->id->bookingProductId()];
         if ($this->additionalServices !== []) {
             $a['additionalServices'] = array_map(
                 static fn (AdditionalService $s): array => ['id' => $s->value],

--- a/src/v4/Enum/Product.php
+++ b/src/v4/Enum/Product.php
@@ -69,9 +69,16 @@ enum Product: string
      * between the given countries" / "customs declarations required for
      * exporting from Norway"), even though the parties are both NO.
      *
-     * For products with no known numeric mapping we fall back to the
-     * enum value — Bring accepts strings for some newer products and
-     * this keeps unknown cases at least as functional as today.
+     * The mapping below covers the products with codes confirmed against
+     * the v3 SDK catalog Bring still accepts in v4. Products NOT in this
+     * match (e.g. HOME_DELIVERY_PARCEL, BUSINESS_PALLET, the home/express
+     * return variants) fall back to the enum string value — Bring
+     * accepts strings for some products and the fallback keeps unknown
+     * cases at least as functional as today. If you hit BOOK-INPUT-025
+     * on a product handled by the fallback, look up its numeric code in
+     * Mybring (Customer numbers → service product line) and add it
+     * here. Do not guess: a wrong numeric code silently books the wrong
+     * product, while the string fallback at worst surfaces a 4xx.
      */
     public function bookingProductId(): string
     {

--- a/src/v4/Enum/Product.php
+++ b/src/v4/Enum/Product.php
@@ -56,4 +56,40 @@ enum Product: string
             default => null,
         };
     }
+
+    /**
+     * Product identifier as Bring's Booking API expects it in product.id.
+     *
+     * The Booking API takes numeric service codes (e.g. "5000" for
+     * BUSINESS_PARCEL, "9000" for BUSINESS_PARCEL_RETURN) — the same
+     * codes the v3 SDK used. Sending the v2 Shipping-Guide string name
+     * (BUSINESS_PARCEL, …) makes Bring's gateway look it up in the
+     * international catalog and reject Norway→Norway routes with
+     * BOOK-INPUT-025 / BOOK_VALIDATION-014 ("product not available
+     * between the given countries" / "customs declarations required for
+     * exporting from Norway"), even though the parties are both NO.
+     *
+     * For products with no known numeric mapping we fall back to the
+     * enum value — Bring accepts strings for some newer products and
+     * this keeps unknown cases at least as functional as today.
+     */
+    public function bookingProductId(): string
+    {
+        $numeric = match ($this) {
+            self::PICKUP_PARCEL => 5800,
+            self::PICKUP_PARCEL_BULK => 5802,
+            self::BUSINESS_PARCEL => 5000,
+            self::BUSINESS_PARCEL_BULK => 5100,
+            self::EXPRESS_NORDIC_0900 => 4850,
+            self::MAILBOX_PARCEL => 3584,
+            self::MAILBOX_PARCEL_TRACKED => 3570,
+            self::CARGO_GROUPAGE => 5300,
+            self::RETURN_PICKUP_PARCEL => 9300,
+            self::RETURN_BUSINESS_PARCEL => 9000,
+            self::RETURN_BUSINESS_PALLET => 9100,
+            default => null,
+        };
+
+        return $numeric === null ? $this->value : (string) $numeric;
+    }
 }

--- a/tests/v4/Endpoint/Booking/BookingApiTest.php
+++ b/tests/v4/Endpoint/Booking/BookingApiTest.php
@@ -47,7 +47,7 @@ final class BookingApiTest extends TestCase
         $request = BookingRequest::single(
             schemaVersion: '1',
             customerNumber: 'PARCELS_NORWAY-10001234567',
-            product: Product::HOME_DELIVERY_PARCEL,
+            product: Product::BUSINESS_PARCEL,
             sender: $sender,
             recipient: $recipient,
             packages: [new Package(weightInKg: 2)],
@@ -67,7 +67,9 @@ final class BookingApiTest extends TestCase
         self::assertArrayNotHasKey('customerNumber', $body, 'customerNumber must not be at request root — Bring expects it under consignments[].product');
         self::assertSame('PARCELS_NORWAY-10001234567', $body['consignments'][0]['product']['customerNumber']);
         self::assertTrue($body['testIndicator']);
-        self::assertSame(Product::HOME_DELIVERY_PARCEL->value, $body['consignments'][0]['product']['id']);
+        // Booking API expects the numeric service code, not the string enum
+        // value (which the Shipping Guide uses). BUSINESS_PARCEL → "5000".
+        self::assertSame('5000', $body['consignments'][0]['product']['id']);
         self::assertSame('EVARSLING', $body['consignments'][0]['product']['additionalServices'][0]['id']);
         self::assertSame('Sender Co', $body['consignments'][0]['parties']['sender']['name']);
         self::assertSame('NO', $body['consignments'][0]['parties']['recipient']['countryCode']);


### PR DESCRIPTION
## Summary

Bring's Booking API expects the **numeric** service code in `product.id` (e.g. `"5000"` for BUSINESS_PARCEL, `"9000"` for the return variant) — the same codes the v3 SDK used. The v4 SDK was sending the string enum value (`"BUSINESS_PARCEL"`), which Bring's gateway looks up in the **international** catalog and rejects Norway→Norway routes with:
- `BOOK-INPUT-025` "The product is not available between the given countries"
- `BOOK_VALIDATION-014` "Customs declarations are required for exporting this product from Norway"

— even though both parties are `"NO"`. This was an unnoticed v3→v4 regression; the existing `BookingApiTest` only checked the incorrect shape against a mock client.

The Shipping Guide path is unchanged: `PriceRequest::toArray` keeps using the string `Product` enum value, which is the correct v2 Shipping Guide convention.

## Change

- `Product::bookingProductId(): string` — returns the numeric service code as a string for products with a known mapping, falls back to the enum value otherwise (so newer products with no v3 numeric counterpart still work via the string Bring accepts in some contexts).
- `BookingProduct::toArray()` calls `bookingProductId()` instead of `$id->value`.
- `BookingApiTest` switched to `BUSINESS_PARCEL` and pins the serialized id to `"5000"`.

Mapped codes (from the v3 numeric catalog Bring still accepts in v4 Booking):

| Code | Product |
|---|---|
| 3570 | MAILBOX_PARCEL_TRACKED |
| 3584 | MAILBOX_PARCEL |
| 4850 | EXPRESS_NORDIC_0900 |
| 5000 | BUSINESS_PARCEL |
| 5100 | BUSINESS_PARCEL_BULK |
| 5300 | CARGO_GROUPAGE |
| 5800 | PICKUP_PARCEL |
| 5802 | PICKUP_PARCEL_BULK |
| 9000 | RETURN_BUSINESS_PARCEL |
| 9100 | RETURN_BUSINESS_PALLET |
| 9300 | RETURN_PICKUP_PARCEL |

Verified the wire shape locally:

```json
"product": { "id": "5000", "customerNumber": "PARCELS_NORWAY-..." }
```

## Test plan

- [x] `vendor/bin/phpunit` — 198 tests, all green
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] Direct JSON dump confirms `product.id` is now `"5000"` for BUSINESS_PARCEL

---
_Generated by [Claude Code](https://claude.ai/code/session_019aSYHW5dD7tg3EJkFp8C9w)_