### PR TITLE
fix(reports): generate report via GET, not POST (Bring returns 405 on POST)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expected this path.
 
 ### Fixed
+- `GenerateReportEndpoint` now issues a **GET** with the report-type filters as
+  query parameters, not a POST with a JSON body. Bring's
+  `/reports/api/generate/{customer}/{reportType}` route only accepts GET (the
+  sibling `generate` / `generate/{customer}` list routes are GET too), so the
+  v4 POST was rejected with `405 Method Not Allowed` and an empty body —
+  surfacing as `Bring API returned HTTP 405 (-: HTTP 405 (empty error body))`.
+  Restores v3 `GenerateReport` behaviour.
 - `RetryClient` no longer burns retry attempts on permanent 4xx failures
   when wrapped around a Guzzle client with the default `http_errors=true`
   setting. A `BadResponseException` whose response is not in the retry

--- a/src/v4/Endpoint/Reports/GenerateReportEndpoint.php
+++ b/src/v4/Endpoint/Reports/GenerateReportEndpoint.php
@@ -49,11 +49,21 @@ final class GenerateReportEndpoint extends AbstractJsonEndpoint
         );
     }
 
-    /** @return array<string, mixed> */
+    /**
+     * Report filters are passed through verbatim, except booleans: Bring
+     * expects the literal strings "true"/"false", but PHP's http_build_query
+     * would serialise a bool as 1/0, which Bring's validation rejects. Mirrors
+     * the explicit bool handling in {@see ListInvoiceNumbersEndpoint}.
+     *
+     * @return array<string, mixed>
+     */
     #[\Override]
     protected function queryParameters(): array
     {
-        return $this->parameters;
+        return array_map(
+            static fn (mixed $value): mixed => is_bool($value) ? ($value ? 'true' : 'false') : $value,
+            $this->parameters,
+        );
     }
 
     /** @param array<mixed, mixed> $decoded */

--- a/src/v4/Endpoint/Reports/GenerateReportEndpoint.php
+++ b/src/v4/Endpoint/Reports/GenerateReportEndpoint.php
@@ -8,12 +8,18 @@ use Bring\Api\Endpoint\AbstractJsonEndpoint;
 use Bring\Api\Http\HttpMethod;
 
 /**
- * POST https://www.mybring.com/reports/api/generate/{customerNumber}/{reportTypeId}.json
+ * GET https://www.mybring.com/reports/api/generate/{customerNumber}/{reportTypeId}.json
+ *
+ * Bring's report-generation route is a GET with the report-type filters
+ * passed as query parameters (the sibling list-available routes on the same
+ * /reports/api/generate base path are GET too). Issuing a POST here makes
+ * Bring's gateway reject the request with 405 Method Not Allowed and an
+ * empty body before the response ever carries an error envelope.
  *
  * Hardcoded to JSON: this endpoint extends AbstractJsonEndpoint, so
  * non-JSON responses would fail to parse here. The format of the
- * eventual report file is controlled separately by the parameters
- * payload, not by the request URL suffix.
+ * eventual report file is controlled separately by the parameters,
+ * not by the request URL suffix.
  *
  * @extends AbstractJsonEndpoint<GenerateReportResponse>
  */
@@ -30,7 +36,7 @@ final class GenerateReportEndpoint extends AbstractJsonEndpoint
     #[\Override]
     public function method(): HttpMethod
     {
-        return HttpMethod::POST;
+        return HttpMethod::GET;
     }
 
     #[\Override]
@@ -43,11 +49,11 @@ final class GenerateReportEndpoint extends AbstractJsonEndpoint
         );
     }
 
-    /** @return array<mixed, mixed>|null */
+    /** @return array<string, mixed> */
     #[\Override]
-    protected function jsonBody(): ?array
+    protected function queryParameters(): array
     {
-        return $this->parameters === [] ? null : $this->parameters;
+        return $this->parameters;
     }
 
     /** @param array<mixed, mixed> $decoded */

--- a/tests/v4/Endpoint/Reports/GenerateReportEndpointTest.php
+++ b/tests/v4/Endpoint/Reports/GenerateReportEndpointTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bring\Api\Tests\Endpoint\Reports;
+
+use Bring\Api\ApiClient;
+use Bring\Api\Auth\Credentials;
+use Bring\Api\Endpoint\Reports\GenerateReportEndpoint;
+use Bring\Api\Tests\Support\RecordingClient;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GenerateReportEndpoint::class)]
+final class GenerateReportEndpointTest extends TestCase
+{
+    private function client(): RecordingClient
+    {
+        return new RecordingClient([
+            new Response(200, ['Content-Type' => 'application/json'], '{"reportId":"abc"}'),
+        ]);
+    }
+
+    public function testUsesGetNotPost(): void
+    {
+        // Regression: Bring's /reports/api/generate route only accepts GET.
+        // A POST is rejected with 405 Method Not Allowed (empty body).
+        $client = $this->client();
+        $api = ApiClient::withCredentials(new Credentials('me@example.com', 'k'), $client);
+
+        $api->reports()->generate('PARCELS_NORWAY-00012341234', 'MASTER-SPECIFIED_INVOICE');
+
+        self::assertSame('GET', $client->lastRequest()->getMethod());
+    }
+
+    public function testHardcodesJsonUrl(): void
+    {
+        $client = $this->client();
+        $api = ApiClient::withCredentials(new Credentials('me@example.com', 'k'), $client);
+
+        $api->reports()->generate('PARCELS_NORWAY-00012341234', 'MASTER-SPECIFIED_INVOICE');
+
+        self::assertStringStartsWith(
+            'https://www.mybring.com/reports/api/generate/PARCELS_NORWAY-00012341234/MASTER-SPECIFIED_INVOICE.json',
+            (string) $client->lastRequest()->getUri(),
+        );
+    }
+
+    public function testParametersGoIntoQueryStringNotBody(): void
+    {
+        $client = $this->client();
+        $api = ApiClient::withCredentials(new Credentials('me@example.com', 'k'), $client);
+
+        $api->reports()->generate(
+            'PARCELS_NORWAY-00012341234',
+            'MASTER-SPECIFIED_INVOICE',
+            ['invoiceNumber' => '12345'],
+        );
+
+        $request = $client->lastRequest();
+        self::assertStringContainsString('invoiceNumber=12345', (string) $request->getUri());
+        // A GET carries no JSON body — the params must not leak into one.
+        self::assertSame('', (string) $request->getBody());
+    }
+}

--- a/tests/v4/Endpoint/Reports/GenerateReportEndpointTest.php
+++ b/tests/v4/Endpoint/Reports/GenerateReportEndpointTest.php
@@ -63,4 +63,23 @@ final class GenerateReportEndpointTest extends TestCase
         // A GET carries no JSON body — the params must not leak into one.
         self::assertSame('', (string) $request->getBody());
     }
+
+    public function testBooleanParametersSerializeAsTrueFalseNotOneZero(): void
+    {
+        // PHP's http_build_query would emit 1/0; Bring expects literal true/false.
+        $client = $this->client();
+        $api = ApiClient::withCredentials(new Credentials('me@example.com', 'k'), $client);
+
+        $api->reports()->generate(
+            'PARCELS_NORWAY-00012341234',
+            'MASTER-SPECIFIED_INVOICE',
+            ['includeSpecification' => true, 'onlyProcessed' => false],
+        );
+
+        $uri = (string) $client->lastRequest()->getUri();
+        self::assertStringContainsString('includeSpecification=true', $uri);
+        self::assertStringContainsString('onlyProcessed=false', $uri);
+        self::assertStringNotContainsString('includeSpecification=1', $uri);
+        self::assertStringNotContainsString('onlyProcessed=0', $uri);
+    }
 }


### PR DESCRIPTION
## Problem

The `import.orders_freight_bring` schedule fails with:

```
Bring API returned HTTP 405 (-: HTTP 405 (empty error body))
```

That schedule runs a Reports API chain — `listInvoiceNumbers → generate → status → download`. The v4 rewrite changed the **"generate report" endpoint from GET to POST**:

- **v3 (`Crakter\BringApi\Clients\Reports\GenerateReport`):** `GET …/reports/api/generate/{cust}/{reportType}`, filters as a query string
- **v4 (`GenerateReportEndpoint`):** `POST` with a JSON body

Bring's `/reports/api/generate/...` route only accepts **GET** (per [Bring's docs](https://developer.bring.com/api/reports/): *"To generate a report, do a GET to the supplied URL"*). The POST is rejected by Bring's gateway with `405 Method Not Allowed` and an empty body — which is why the surfaced message has an empty error code (`-`) and no error envelope. The two sibling endpoints on the same base path (`ListAvailableCustomersEndpoint`, `ListAvailableReportsForCustomerEndpoint`) already use GET; only `GenerateReportEndpoint` was POST.

## Fix

`src/v4/Endpoint/Reports/GenerateReportEndpoint.php`:
- `method()` → `GET` (was `POST`)
- parameters now emitted as a **query string** (`queryParameters()`) instead of a JSON body
- updated docblock

Plus a regression test (`tests/v4/Endpoint/Reports/GenerateReportEndpointTest.php`) asserting the GET method, the `.json` URL, and query-string placement, and a `CHANGELOG.md` entry under Unreleased → Fixed.

## Verification

- `vendor/bin/phpunit` — 201 tests pass (3 new + existing Reports tests green)
- PHPStan level 8 — clean on the changed file
- php-cs-fixer — no style changes

> Note: not exercised against the live Bring API (no Mybring credentials in CI); verified via Bring's docs, the v3↔v4 diff, and unit tests.

## Downstream

`crakter/purchase` pins this library to a master commit in `composer.lock`; after merge, run `composer update crakter/bringapi` there to pick up the fix.

https://claude.ai/code/session_01GwRgBSHYS7hXV7nBgDTanT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwRgBSHYS7hXV7nBgDTanT)_