### PR TITLE
fix(shipping-guide): map express to 4850, not 0335

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,15 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of the v2 string name. Shipping Guide v2 prices by numeric code,
   so sending `EXPRESS_NORDIC_0900` (and the other string names) returned an
   empty product list — i.e. "no price". Products without a confirmed numeric
-  code fall back to the string value, unchanged. Note: Express Nordic 09:00
-  (`0335`) is being decommissioned by Bring on 2026-09-01 in favour of Bring
-  Courier & Express (`3620` + VAS `1171`).
+  code fall back to the string value, unchanged. The `EXPRESS_NORDIC_0900`
+  case maps to `4850` (Business Parcel Express / "Pakke til bedrift ekspress"),
+  the everyday express parcel — not Bring's separate "Express Nordic 09:00"
+  courier product (`0335`).
 
 ### Added
 - `Product::shippingGuideCode(): ?string` — the numeric service code the
-  Shipping Guide v2 endpoints expect, string-typed so leading zeros survive
-  (`0335`). Distinct from `legacyNumericCode()`, which carries the historical
-  in-app codes (Express Nordic 09:00 is `4850` there, `0335` here).
+  Shipping Guide v2 endpoints expect, string-typed (leading-zero safe).
 
 ### Changed
 - `TrackingApi::signature(string)` and `SignatureEndpoint::__construct`

--- a/src/v4/Enum/Product.php
+++ b/src/v4/Enum/Product.php
@@ -70,19 +70,21 @@ enum Product: string
      * parameter.
      *
      * Shipping Guide v2 identifies products by Bring's numeric service codes
-     * (e.g. "5800" Pickup Parcel, "5600" Home Delivery, "0335" Express Nordic
-     * 09:00). It does NOT price the v2 string names (EXPRESS_NORDIC_0900, …) —
-     * sending those returns an empty product list ("no price"). Codes are
-     * returned as strings so leading zeros survive ("0335" must not become 335).
+     * (e.g. "5800" Pickup Parcel, "5600" Home Delivery, "5000" Business Parcel,
+     * "4850" Business Parcel Express / "Pakke til bedrift ekspress"). It does
+     * NOT price the v2 string names (EXPRESS_NORDIC_0900, …) — sending those
+     * returns an empty product list ("no price"). Codes are returned as strings
+     * so any future leading-zero code survives intact.
      *
      * Returns null for products whose Shipping Guide code is not yet confirmed;
      * callers should fall back to the enum string value for those so unknown
      * products are no worse off than before.
      *
-     * NOTE: Express Nordic 09:00 (0335) is being decommissioned by Bring on
-     * 2026-09-01. The successor is Bring Courier & Express (3620) with VAS 1171
-     * — that migration needs both a product and an additional-service change,
-     * so it is intentionally NOT silently mapped here.
+     * NOTE on the EXPRESS_NORDIC_0900 case: despite the enum name, this catalog
+     * uses it for Business Parcel Express (4850) — the everyday express parcel,
+     * confirmed against Bring's revised-services list (5000/5100/5300/5600/5800/
+     * 4850). It is NOT Bring's separate time-definite courier product "Express
+     * Nordic 09:00" (0335), which is being decommissioned 2026-09-01.
      */
     public function shippingGuideCode(): ?string
     {
@@ -90,7 +92,7 @@ enum Product: string
             self::PICKUP_PARCEL => '5800',
             self::HOME_DELIVERY_PARCEL => '5600',
             self::BUSINESS_PARCEL => '5000',
-            self::EXPRESS_NORDIC_0900 => '0335',
+            self::EXPRESS_NORDIC_0900 => '4850',
             self::MAILBOX_PARCEL => '3584',
             self::MAILBOX_PARCEL_TRACKED => '3570',
             default => null,

--- a/tests/v4/Endpoint/Shipping/PriceRequestTest.php
+++ b/tests/v4/Endpoint/Shipping/PriceRequestTest.php
@@ -33,13 +33,14 @@ final class PriceRequestTest extends TestCase
         self::assertSame(['5000', '5800'], $q['product']);
     }
 
-    public function testExpressNordicKeepsLeadingZeroAndUsesShippingGuideCode(): void
+    public function testExpressUsesNumericShippingGuideCode(): void
     {
         $q = $this->request(Product::EXPRESS_NORDIC_0900)->toQuery();
 
-        // 0335 (Shipping Guide v2), NOT the string name and NOT the legacy
-        // in-app code 4850 — and the leading zero must survive.
-        self::assertSame(['0335'], $q['product']);
+        // 4850 = Business Parcel Express ("Pakke til bedrift ekspress"), the
+        // express product this catalog uses — NOT the v2 string name, and NOT
+        // the unrelated "Express Nordic 09:00" courier code 0335.
+        self::assertSame(['4850'], $q['product']);
     }
 
     public function testUnmappedProductFallsBackToStringValue(): void


### PR DESCRIPTION
## Correction

Follow-up to #64. That PR shipped the wrong numeric code for express: `Product::shippingGuideCode()` mapped `EXPRESS_NORDIC_0900` → `0335`. On master this means express price lookups now send `0335` — a different product ("Express Nordic 09:00" courier, decommissioned 2026-09-01) that isn't available on the account, so express still returns **no price**.

The correct Shipping Guide code is **`4850`** = Business Parcel Express ("Pakke til bedrift ekspress") — confirmed against Bring's [revised-services list](https://developer.bring.com/api/services/revisedservice/) (`5000 / 5100 / 5300 / 5600 / 5800 / 4850`), and matching both the in-app calculator's own code and `legacyNumericCode()`.

## Change

- `shippingGuideCode()`: `EXPRESS_NORDIC_0900` → `'4850'` (was `'0335'`).
- Updated `PriceRequestTest` to assert `['4850']`.
- Corrected docblock + CHANGELOG (removed the inaccurate 0335 decommission note; clarified the enum name vs. the actual product).

Express codes now round-trip cleanly: `4850 → EXPRESS_NORDIC_0900 → 4850`.

## Verification

- PHPUnit: 4/4 in `PriceRequestTest`, full suite green
- PHPStan: clean (exit 0)

## Note

The `?? $p->value` fallback for products without a confirmed numeric code still emits the literal v2 string name. It never triggers for the calculator's products (4850/5800/5000, all mapped), but is a latent issue for unmapped products if Bring has deprecated the string names wholesale — left as-is pending confirmation of which string names still price.

https://claude.ai/code/session_01TLPjgivGN5mopPrs4vcfBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLPjgivGN5mopPrs4vcfBp)_